### PR TITLE
Add e2e tests for 'Discharge Instructions', 'Discharge Summary', 'Procedure Note' and 'Visit Note' forms.

### DIFF
--- a/e2e/tests/allergies.spec.ts
+++ b/e2e/tests/allergies.spec.ts
@@ -53,7 +53,7 @@ test('Edit an allergy', async ({}) => {
   await expect(dataRow).toContainText(/gas and bloating after eating boiled eggs/i);
 
   // replay
-  await allergiesPage.editPatientAllergies();
+  await allergiesPage.updatePatientAllergies();
 
   // verify
   await expect(dataRow).not.toContainText(/dairy food/i);

--- a/e2e/tests/appointments.spec.ts
+++ b/e2e/tests/appointments.spec.ts
@@ -44,7 +44,7 @@ test('Edit an appointment', async ({ page }) => {
   await expect(page.getByRole('cell', { name: /this is an appointment./i })).toBeVisible();
 
   // replay
-  appointmentsPage.editPatientAppointment();
+  appointmentsPage.updatePatientAppointment();
   
   // verify
   await expect(page.getByRole('cell', { name: /general medicine service/i })).not.toBeVisible();

--- a/e2e/tests/conditions.spec.ts
+++ b/e2e/tests/conditions.spec.ts
@@ -46,7 +46,7 @@ test('Edit a condition', async ({page}) => {
   await expect(dataRow).toContainText(/active/i);
 
   // replay
-  await conditionsPage.editPatientCondition();
+  await conditionsPage.updatePatientCondition();
 
   // verify
   await page.getByRole('combobox', { name: /show/i }).click();

--- a/e2e/tests/diagnosis.spec.ts
+++ b/e2e/tests/diagnosis.spec.ts
@@ -2,17 +2,17 @@ import { test, expect } from '@playwright/test';
 import { HomePage } from '../utils/pages/home-page';
 import { VisitsPage } from '../utils/pages/visits-page';
 import { RegistrationPage } from '../utils/pages/registration-page';
-import { VisitNotePage } from '../utils/pages/visit-note-page';
+import { DiagnosisPage } from '../utils/pages/visit-note-page';
 
 let homePage: HomePage;
 let visitsPage: VisitsPage;
-let visitNotePage: VisitNotePage;
+let diagnosisPage: DiagnosisPage;
 let registrationPage: RegistrationPage;
 
 test.beforeEach(async ({ page }) => {
   homePage = new HomePage(page);
   visitsPage = new VisitsPage(page);
-  visitNotePage = new VisitNotePage(page);
+  diagnosisPage = new DiagnosisPage(page);
   registrationPage = new RegistrationPage(page);
 
   await homePage.login();
@@ -20,13 +20,13 @@ test.beforeEach(async ({ page }) => {
   await registrationPage.createPatient();
 });
 
-test('Add a visit note', async ({ page }) => {
+test('Add a diagnosis', async ({ page }) => {
   // setup
   await visitsPage.startPatientVisit();
   
   // replay
-  await visitNotePage.navigateToVisitNotePage();
-  await visitNotePage.addVisitNote();
+  await diagnosisPage.navigateToDiagnosisPage();
+  await diagnosisPage.addDiagnosis();
 
   // verify
   await visitsPage.navigateToVisitsPage();
@@ -34,15 +34,15 @@ test('Add a visit note', async ({ page }) => {
   await expect(page.getByText(/patient has excessive thirst, frequent urination, nausea and vomiting/i)).toBeVisible();
 });
 
-test('Delete a visit note', async ({ page }) => {
+test('Delete a diagnosis', async ({ page }) => {
   // setup
   await visitsPage.startPatientVisit();
-  await visitNotePage.navigateToVisitNotePage();
-  await visitNotePage.addVisitNote();
+  await diagnosisPage.navigateToDiagnosisPage();
+  await diagnosisPage.addDiagnosis();
 
   // replay
   await visitsPage.navigateToVisitsPage();
-  await visitNotePage.deleteVisitNote();
+  await diagnosisPage.deleteDiagnosis();
 
   // verify
   await expect(page.getByLabel(/all encounters/i).getByText(/there are no encounters to display for this patient/i)).toBeVisible();

--- a/e2e/tests/discharge-instructions-form.spec.ts
+++ b/e2e/tests/discharge-instructions-form.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+import { delay, HomePage } from '../utils/pages/home-page';
+import { VisitsPage } from '../utils/pages/visits-page';
+import { patientName, RegistrationPage } from '../utils/pages/registration-page';
+import { 
+  ClinicalFormsPage,
+  additionalInstructions,
+  dischargeMedications,
+  followUpAppointment,
+  reasonsToContactDoctor,
+  treatmentInformationAndInstructions,
+  updatedAdditionalInstructions,
+  updatedDischargeMedications,
+  updatedFollowUpAppointment,
+  updatedReasonsToContactDoctor,
+   } from '../utils/pages/clinical-forms-page';
+
+let homePage: HomePage;
+let visitsPage: VisitsPage;
+let registrationPage: RegistrationPage;
+let formsPage: ClinicalFormsPage;
+
+test.beforeEach(async ({ page }) => {
+  homePage = new HomePage(page);
+  visitsPage = new VisitsPage(page);
+  formsPage = new ClinicalFormsPage(page);
+  registrationPage = new RegistrationPage(page);
+
+  await homePage.login();
+  await registrationPage.navigateToRegistrationForm();
+  await registrationPage.createPatient();
+  await visitsPage.startPatientVisit();
+  await formsPage.navigateToClinicalForms();
+});
+
+test('Add discharge instructions', async ({ page }) => {
+  // setup
+  await formsPage.navigateToDischargeInstructionsForm();
+
+  // replay
+  await formsPage.fillDischargeInstructionsForm();
+  await formsPage.saveForm();
+
+  // verify
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(treatmentInformationAndInstructions)).toBeVisible();
+  await expect(page.getByText(reasonsToContactDoctor)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).toBeVisible();
+  await expect(page.getByText(followUpAppointment)).toBeVisible();
+  await expect(page.getByText(additionalInstructions)).toBeVisible();
+});
+
+test('Edit discharge instructions', async ({ page }) => {
+  // setup
+  await formsPage.navigateToDischargeInstructionsForm();
+  await formsPage.fillDischargeInstructionsForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(treatmentInformationAndInstructions)).toBeVisible();
+  await expect(page.getByText(reasonsToContactDoctor)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).toBeVisible();
+  await expect(page.getByText(followUpAppointment)).toBeVisible();
+  await expect(page.getByText(additionalInstructions)).toBeVisible();
+
+  // replay
+  await formsPage.updateDischargeInstructions();
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(treatmentInformationAndInstructions)).toBeVisible();
+  await expect(page.getByText(reasonsToContactDoctor)).not.toBeVisible();
+  await expect(page.getByText(updatedReasonsToContactDoctor)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).not.toBeVisible();
+  await expect(page.getByText(updatedDischargeMedications)).toBeVisible();
+  await expect(page.getByText(followUpAppointment)).not.toBeVisible();
+  await expect(page.getByText(updatedFollowUpAppointment)).toBeVisible();
+  await expect(page.getByText(additionalInstructions)).not.toBeVisible();
+  await expect(page.getByText(updatedAdditionalInstructions)).toBeVisible();
+});
+
+test('Delete discharge instructions', async ({ page }) => {
+  // setup
+  await formsPage.navigateToDischargeInstructionsForm();
+  await formsPage.fillDischargeInstructionsForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(treatmentInformationAndInstructions)).toBeVisible();
+  await expect(page.getByText(reasonsToContactDoctor)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).toBeVisible();
+  await expect(page.getByText(followUpAppointment)).toBeVisible();
+  await expect(page.getByText(additionalInstructions)).toBeVisible();
+
+  // replay
+  await page.getByRole('button', { name: /danger delete this encounter/i }).click();
+  await page.getByRole('button', { name: 'danger Delete', exact: true }).click(), delay(3000);
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await expect(page.getByText(/There are no encounters to display for this patient/).nth(0)).toBeVisible();
+});
+
+test.afterEach(async ({}) => {
+  await homePage.voidPatient();
+});

--- a/e2e/tests/discharge-summary-form.spec.ts
+++ b/e2e/tests/discharge-summary-form.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { delay, HomePage } from '../utils/pages/home-page';
+import { VisitsPage } from '../utils/pages/visits-page';
+import { patientName, RegistrationPage } from '../utils/pages/registration-page';
+import { 
+  ClinicalFormsPage,
+  consultations,
+  dischargeInstructions,
+  dischargeMedications,
+  dischargeTo,
+  hospitalCourse,
+  procedure,
+  updatedConsultations,
+  updatedDischargeMedications,
+  updatedHospitalCourse,
+   } from '../utils/pages/clinical-forms-page';
+
+let homePage: HomePage;
+let visitsPage: VisitsPage;
+let registrationPage: RegistrationPage;
+let formsPage: ClinicalFormsPage;
+
+test.beforeEach(async ({ page }) => {
+  homePage = new HomePage(page);
+  visitsPage = new VisitsPage(page);
+  formsPage = new ClinicalFormsPage(page);
+  registrationPage = new RegistrationPage(page);
+
+  await homePage.login();
+  await registrationPage.navigateToRegistrationForm();
+  await registrationPage.createPatient();
+  await visitsPage.startPatientVisit();
+  await formsPage.navigateToClinicalForms();
+});
+
+test('Add discharge summary', async ({ page }) => {
+  // setup
+  await formsPage.navigateToDischargeSummaryForm();
+
+  // replay
+  await formsPage.fillDischargeSummaryForm();
+  await formsPage.saveForm();
+
+  // verify
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(procedure)).toBeVisible();
+  await expect(page.getByText(consultations)).toBeVisible();
+  await expect(page.getByText(hospitalCourse)).toBeVisible();
+  await expect(page.getByText(dischargeTo)).toBeVisible();
+  await expect(page.getByText(/acute cholecystitis/i)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).toBeVisible();
+  await expect(page.getByText(dischargeInstructions)).toBeVisible();
+});
+
+test('Edit discharge summary', async ({ page }) => {
+  // setup
+  await formsPage.navigateToDischargeSummaryForm();
+  await formsPage.fillDischargeSummaryForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(procedure)).toBeVisible();
+  await expect(page.getByText(consultations)).toBeVisible();
+  await expect(page.getByText(hospitalCourse)).toBeVisible();
+  await expect(page.getByText(dischargeTo)).toBeVisible();
+  await expect(page.getByText(/acute cholecystitis/i)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).toBeVisible();
+  await expect(page.getByText(dischargeInstructions)).toBeVisible();
+
+  // replay
+  await formsPage.updateDischargeSummary();
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(consultations)).not.toBeVisible();
+  await expect(page.getByText(updatedConsultations)).toBeVisible();
+  await expect(page.getByText(hospitalCourse)).not.toBeVisible();
+  await expect(page.getByText(updatedHospitalCourse)).toBeVisible();
+  await expect(page.getByText(/acute cholecystitis/i)).not.toBeVisible();
+  await expect(page.getByText(/acute peptic ulcer with perforation/i)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).not.toBeVisible();
+  await expect(page.getByText(updatedDischargeMedications)).toBeVisible();
+  await expect(page.getByText(dischargeInstructions)).not.toBeVisible();
+  await expect(page.getByText(updatedDischargeMedications)).toBeVisible();
+});
+
+test('Delete discharge summary', async ({ page }) => {
+  // setup
+  await formsPage.navigateToDischargeSummaryForm();
+  await formsPage.fillDischargeSummaryForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(procedure)).toBeVisible();
+  await expect(page.getByText(consultations)).toBeVisible();
+  await expect(page.getByText(hospitalCourse)).toBeVisible();
+  await expect(page.getByText(dischargeTo)).toBeVisible();
+  await expect(page.getByText(/acute cholecystitis/i)).toBeVisible();
+  await expect(page.getByText(dischargeMedications)).toBeVisible();
+  await expect(page.getByText(dischargeInstructions)).toBeVisible();
+
+  // replay
+  await page.getByRole('button', { name: /danger delete this encounter/i }).click();
+  await page.getByRole('button', { name: 'danger Delete', exact: true }).click(), delay(3000);
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await expect(page.getByText(/There are no encounters to display for this patient/).nth(0)).toBeVisible();
+});
+
+test.afterEach(async ({}) => {
+  await homePage.voidPatient();
+});

--- a/e2e/tests/procedure-note-form.spec.ts
+++ b/e2e/tests/procedure-note-form.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+import { delay, HomePage } from '../utils/pages/home-page';
+import { VisitsPage } from '../utils/pages/visits-page';
+import { patientName, RegistrationPage } from '../utils/pages/registration-page';
+import { 
+  ClinicalFormsPage,
+  complications,
+  consent,
+  indication,
+  physcian,
+  procedure,
+  procedureSummary,
+  updatedComplications,
+  updatedConsent,
+  UpdatedProcedureSummary,
+   } from '../utils/pages/clinical-forms-page';
+
+let homePage: HomePage;
+let visitsPage: VisitsPage;
+let registrationPage: RegistrationPage;
+let formsPage: ClinicalFormsPage;
+
+test.beforeEach(async ({ page }) => {
+  homePage = new HomePage(page);
+  visitsPage = new VisitsPage(page);
+  formsPage = new ClinicalFormsPage(page);
+  registrationPage = new RegistrationPage(page);
+
+  await homePage.login();
+  await registrationPage.navigateToRegistrationForm();
+  await registrationPage.createPatient();
+  await visitsPage.startPatientVisit();
+  await formsPage.navigateToClinicalForms();
+});
+
+test('Add procedure note', async ({ page }) => {
+  // setup
+  await formsPage.navigateToProcedureNoteForm();
+
+  // replay
+  await formsPage.fillProcedureNoteForm();
+  await formsPage.saveForm();
+
+  // verify
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(procedure)).toBeVisible();
+  await expect(page.getByText(indication)).toBeVisible();
+  await expect(page.getByText(physcian)).toBeVisible();
+  await expect(page.getByText(consent)).toBeVisible();
+  await expect(page.getByText(/local anesthesia and sedation/i)).toBeVisible();
+  await expect(page.getByText(procedureSummary)).toBeVisible();
+  await expect(page.getByText(complications)).toBeVisible();
+});
+
+test('Edit procedure note', async ({ page }) => {
+  // setup
+  await formsPage.navigateToProcedureNoteForm();
+  await formsPage.fillProcedureNoteForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(procedure)).toBeVisible();
+  await expect(page.getByText(indication)).toBeVisible();
+  await expect(page.getByText(physcian)).toBeVisible();
+  await expect(page.getByText(consent)).toBeVisible();
+  await expect(page.getByText(/local anesthesia and sedation/i)).toBeVisible();
+  await expect(page.getByText(procedureSummary)).toBeVisible();
+  await expect(page.getByText(complications)).toBeVisible();
+
+  // replay
+  await formsPage.updateProcedureNote();
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(consent)).not.toBeVisible();
+  await expect(page.getByText(updatedConsent)).toBeVisible();
+  await expect(page.getByText(/local anesthesia and sedation/i)).not.toBeVisible();
+  await expect(page.getByText(/monitored anesthesia care/i)).toBeVisible();
+  await expect(page.getByText(procedureSummary)).not.toBeVisible();
+  await expect(page.getByText(UpdatedProcedureSummary)).toBeVisible();
+  await expect(page.getByText(complications)).not.toBeVisible();
+  await expect(page.getByText(updatedComplications)).toBeVisible();
+});
+
+test('Delete procudure note', async ({ page }) => {
+  // setup
+  await formsPage.navigateToProcedureNoteForm();
+  await formsPage.fillProcedureNoteForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.getByText(procedure)).toBeVisible();
+  await expect(page.getByText(indication)).toBeVisible();
+  await expect(page.getByText(physcian)).toBeVisible();
+  await expect(page.getByText(consent)).toBeVisible();
+  await expect(page.getByText(/local anesthesia and sedation/i)).toBeVisible();
+  await expect(page.getByText(procedureSummary)).toBeVisible();
+  await expect(page.getByText(complications)).toBeVisible();
+
+  // replay
+  await page.getByRole('button', { name: /danger delete this encounter/i }).click();
+  await page.getByRole('button', { name: 'danger Delete', exact: true }).click(), delay(3000);
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToEncounterPage();
+  await expect(page.getByText(/There are no encounters to display for this patient/).nth(0)).toBeVisible();
+});
+
+test.afterEach(async ({}) => {
+  await homePage.voidPatient();
+});

--- a/e2e/tests/program-enrollment.spec.ts
+++ b/e2e/tests/program-enrollment.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { HomePage } from '../utils/pages/home-page';
 import { VisitsPage } from '../utils/pages/visits-page';
-import { RegistrationPage } from '../utils/pages/registration-page';
+import { patientName, RegistrationPage } from '../utils/pages/registration-page';
 import { ProgramsPage } from '../utils/pages/program-page';
 
 let homePage: HomePage;
@@ -55,16 +55,18 @@ test('Edit a program enrollment', async ({ page }) => {
   await expect(dataRow).toContainText(/completed on 20-Aug-2024/i);
 
   // replay
-  await programsPage.editPatientProgramEnrollment();
+  await programsPage.updatePatientProgramEnrollment();
 
   // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await programsPage.navigateToProgramsPage();
   await expect(dataRow).toContainText(/hiv care and treatment/i);
   await expect(dataRow).not.toContainText(/outpatient clinic/i);
   await expect(dataRow).toContainText(/community outreach/i);
   await expect(dataRow).not.toContainText(/15-Aug-2024/i);
-  await expect(dataRow).toContainText(/16-Aug-2024/i);
+  await expect(dataRow).toContainText(/16-Sept-2024/i);
   await expect(dataRow).not.toContainText(/completed on 20-Aug-2024/i);
-  await expect(dataRow).toContainText(/completed on 21-Aug-2024/i);
+  await expect(dataRow).toContainText(/completed on 21-Sept-2024/i);
 });
 
 test.afterEach(async ({}) => {

--- a/e2e/tests/visit-note-form.spec.ts
+++ b/e2e/tests/visit-note-form.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from '../utils/pages/home-page';
+import { VisitsPage } from '../utils/pages/visits-page';
+import { patientName, RegistrationPage } from '../utils/pages/registration-page';
+import { ClinicalFormsPage, updatedVisitNote, visitNote } from '../utils/pages/clinical-forms-page';
+
+let homePage: HomePage;
+let visitsPage: VisitsPage;
+let registrationPage: RegistrationPage;
+let formsPage: ClinicalFormsPage;
+
+test.beforeEach(async ({ page }) => {
+  homePage = new HomePage(page);
+  visitsPage = new VisitsPage(page);
+  formsPage = new ClinicalFormsPage(page);
+  registrationPage = new RegistrationPage(page);
+
+  await homePage.login();
+  await registrationPage.navigateToRegistrationForm();
+  await registrationPage.createPatient();
+  await visitsPage.startPatientVisit();
+  await formsPage.navigateToClinicalForms();
+});
+
+test('Add a visit note', async ({ page }) => {
+  // setup
+  await formsPage.navigateToVisitNoteForm();
+
+  // replay
+  await formsPage.fillVisitNoteForm();
+  await formsPage.saveForm();
+
+  // verify
+  await visitsPage.navigateToVisitsPage();
+  await expect(page.getByText(visitNote)).toBeVisible();
+});
+
+test('Edit a visit note', async ({ page }) => {
+  // setup
+  await formsPage.navigateToVisitNoteForm();
+  await formsPage.fillVisitNoteForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await expect(page.getByText(visitNote)).toBeVisible();
+
+  // replay
+  await formsPage.updateVisitNote();
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToNotesPage();
+  await expect(page.getByText(/Notes/)).toBeVisible();
+  await expect(page.getByText(visitNote)).not.toBeVisible();
+  await expect(page.getByText(updatedVisitNote)).toBeVisible();
+});
+
+test('Delete a visit note', async ({ page }) => {
+  // setup
+  await formsPage.navigateToVisitNoteForm();
+  await formsPage.fillVisitNoteForm();
+  await formsPage.saveForm();
+  await visitsPage.navigateToVisitsPage();
+  await expect(page.getByText(visitNote)).toBeVisible();
+
+  // replay
+  await formsPage.deleteEncounter();
+
+  // verify
+  await homePage.searchPatient(`${patientName.firstName + ' ' + patientName.givenName}`);
+  await visitsPage.navigateToVisitsPage();
+  await formsPage.navigateToNotesPage();
+  await expect(page.getByRole('heading', {name: /notes/i})).toBeVisible();
+  await expect(page.getByText(visitNote)).not.toBeVisible();
+  await expect(page.getByText(/there are no notes to display for this patient/i)).toBeVisible();
+});
+
+test.afterEach(async ({}) => {
+  await homePage.voidPatient();
+});

--- a/e2e/tests/visits.spec.ts
+++ b/e2e/tests/visits.spec.ts
@@ -38,7 +38,7 @@ test('Edit patient visit', async ({ page }) => {
   await expect(page.getByRole('heading', {name: 'Facility Visit'})).toBeVisible();
 
   // replay
-  await visitsPage.editPatientVisit();
+  await visitsPage.updatePatientVisit();
 
   // verify
   await expect(page.getByRole('heading', {name: 'Facility Visit'})).not.toBeVisible();

--- a/e2e/utils/pages/allergies-page.ts
+++ b/e2e/utils/pages/allergies-page.ts
@@ -21,7 +21,7 @@ export class AllergiesPage {
     await expect(this.page.getByText(/allergy saved/i)).toBeVisible(), delay(2000);
   }
 
-  async editPatientAllergies() {
+  async updatePatientAllergies() {
     await this.page.getByRole('button', { name: /options/i }).nth(0).click();
     await this.page.getByRole('menuitem', { name: /edit/i }).click();
     await this.page.getByPlaceholder(/select the allergen/i).click();

--- a/e2e/utils/pages/appoitnments-page.ts
+++ b/e2e/utils/pages/appoitnments-page.ts
@@ -21,7 +21,7 @@ export class AppointmentsPage {
     await this.page.getByRole('tab', { name: /today/i }).click();
   }
 
-  async editPatientAppointment() {
+  async updatePatientAppointment() {
     await this.page.getByRole('tab', { name: /today/i }).click();
     await this.page.getByRole('button', { name: /options/i }).click();
     await this.page.getByRole('menuitem', { name: /edit/i }).click();

--- a/e2e/utils/pages/clinical-forms-page.ts
+++ b/e2e/utils/pages/clinical-forms-page.ts
@@ -1,0 +1,157 @@
+import { expect, type Page } from '@playwright/test';
+import { delay } from './home-page';
+
+export const treatmentInformationAndInstructions = `Condition Diagnosed: Hypertension.\nTake the medication once daily in the morning, preferably at the same time each day to maintain consistency.`;
+export const reasonsToContactDoctor = `Persistent headaches, blurred vision, or dizziness that does not improve.`;
+export const updatedReasonsToContactDoctor = `Persistent headaches, blurred vision, and dizziness that does not improve.`;
+export const dischargeMedications = `Aspirin 81 mg (Antiplatelet).\nDosage: Take 1 tablet by mouth once a day.\nInstructions: Take with food to avoid stomach upset.`;
+export const updatedDischargeMedications = `Aspirin 81 mg (Antiplatelet).\nDosage: Take 2 tablets by mouth once a day.\nInstructions: Take with food to avoid stomach upset.`;
+export const followUpAppointment = `Date: March 10, 2025.\nTime: 10:30 AM.\nLocation: ABC Medical Center, Room 205.\nProvider: Dr. Allen Hanandez, Cardiologist.`;
+export const updatedFollowUpAppointment = `Date: March 14, 2025.\nTime: 11:30 AM.\nLocation: ABC Medical Center, Room 205.\nProvider: Dr. Allen Hanandez, Cardiologist.`;
+export const additionalInstructions = `Aim for at least 30 minutes of moderate exercise, such as walking or swimming, 5 days a week.`;
+export const updatedAdditionalInstructions = `Aim for at least 25 minutes of moderate exercise, such as walking or swimming, 5 days a week.`;
+export const visitNote = `Continue current antihypertensive regimen. Encourage home blood pressure monitoring and follow-up in 2 months.`;
+export const updatedVisitNote = `Continue current antihypertensive regimen. Encourage home blood pressure monitoring and follow-up in 1 month.`;
+export const procedure = `A sterile spinal needle (20-gauge or appropriate size) was inserted into the L3-L4 interspace, aiming toward the midline, and advanced gently until cerebrospinal fluid (CSF) was obtained.`;
+export const indication = `Suspicious skin lesion (possible melanoma).`;
+export const consent = `Patient verbally agreed to proceed and understands the procedure, including potential complications (e.g., headache, bleeding, infection).`;
+export const updatedConsent = `The procedure was thoroughly explained to the patient, including its purpose, risks, and potential complications (e.g., bleeding, infection, scarring).`;
+export const physcian = `Dr. Sarah Hanandez, MD`;
+export const complications = `No excessive bleeding, signs of infection, or other complications were noted at the time of the procedure`;
+export const updatedComplications = `The patient tolerated the procedure well`;
+export const procedureSummary = `The patient was positioned in a reclining chair with the right arm exposed for easy access to the lesion.`;
+export const UpdatedProcedureSummary = `1% lidocaine was injected around the lesion to anesthetize the area, and the patient tolerated this well without any discomfort.`;
+export const consultations = `Consultation was requested for evaluation of chest pain. The chest pain was confirmed was non-cardiac in origin and attributed it to a musculoskeletal issue.`;
+export const updatedConsultations = `No further cardiology intervention was required.`;
+export const hospitalCourse = `The patient was admitted for evaluation of acute chest pain and fever.`;
+export const updatedHospitalCourse = `The patient was started on pain management for musculoskeletal chest pain and received supportive care for fever.`;
+export const dischargeTo = `The patient is being discharged to home with family support.`;
+export const dischargeInstructions = `Rest and avoid heavy physical exertion for the next 7 days.Gradually resume normal activities as tolerated,`;
+export const updatedDischargeInstructions = `Resume a regular diet. No special restrictions.`;
+
+export class ClinicalFormsPage {
+  constructor(readonly page: Page) {}
+
+  readonly formsTable = () => this.page.getByRole('table', { name: /forms/i });
+
+  async navigateToClinicalForms() {
+    await this.page.getByLabel(/clinical forms/i, { exact: true }).click();
+    await expect(this.page.getByRole('cell', { name: /discharge instructions/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /discharge summary/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /procedure note/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /visit note/i, exact: true })).toBeVisible();
+  }
+
+  async navigateToVisitNoteForm() {
+    await this.page.getByText(/Visit Note/).click();
+    await expect(this.page.getByText(/Visit Note/)).toBeVisible();
+  }
+
+  async navigateToDischargeInstructionsForm() {
+    await this.page.getByText(/discharge instructions/i).click();
+    await expect(this.page.getByText(/discharge instructions/i)).toBeVisible();
+  }
+
+  async navigateToDischargeSummaryForm() {
+    await this.page.getByText(/discharge summary/i).click();
+    await expect(this.page.getByText(/discharge summary/i)).toBeVisible();
+  }
+
+  async navigateToProcedureNoteForm() {
+    await this.page.getByText(/procedure note/i).click();
+    await expect(this.page.getByText(/procedure note/i)).toBeVisible();
+  }
+
+  async navigateToNotesPage() {
+    await this.page.getByRole('tab', { name: /notes/i }).click();
+  }
+
+  async navigateToEncounterPage() {
+    await this.page.getByRole('tab', { name: /Encounters/, exact: true }).click();
+  }
+
+  async fillVisitNoteForm() {
+    await this.page.locator('#visitNote').fill(visitNote);
+  }
+
+  async updateVisitNote() {
+    await this.page.getByRole('tab', { name: /Encounters/, exact: true }).click();
+    await this.page.getByRole('button', { name: /expand current row/i }).click();
+    await this.page.getByRole('button', { name: /edit this encounter/i }).click();
+    await this.page.locator('#visitNote').fill(updatedVisitNote);
+    await this.page.getByRole('button', { name: /save/i }).click();
+    await expect(this.page.getByText(/record updated/i)).toBeVisible(), delay(2000);
+  }
+
+  async deleteEncounter() {
+    await this.page.getByRole('tab', { name: /Encounters/, exact: true }).click();
+    await this.page.getByRole('button', { name: /expand current row/i }).click();
+    await this.page.getByRole('button', { name: /danger delete this encounter/i }).click();
+    await this.page.getByRole('button', { name: 'danger Delete', exact: true }).click(), delay(2000);
+  }
+
+  async fillDischargeInstructionsForm() {
+    await this.page.locator('#dischargeInstructionsTIIs').fill(treatmentInformationAndInstructions);
+    await this.page.locator('#dischargeInstructionsRCDs').fill(reasonsToContactDoctor);
+    await this.page.locator('#dischargeInstructionsDischargeMedications').fill(dischargeMedications);
+    await this.page.locator('#dischargeInstructionsFollowUpAppointments').fill(followUpAppointment);
+    await this.page.locator('#dischargeInstructionsAdditionalInstructions').fill(additionalInstructions);
+  }
+
+  async updateDischargeInstructions() {
+    await this.page.getByRole('button', { name: /edit this encounter/i }).click();
+    await this.page.locator('#dischargeInstructionsTIIs').fill(treatmentInformationAndInstructions);
+    await this.page.locator('#dischargeInstructionsRCDs').fill(updatedReasonsToContactDoctor);
+    await this.page.locator('#dischargeInstructionsDischargeMedications').fill(updatedDischargeMedications);
+    await this.page.locator('#dischargeInstructionsFollowUpAppointments').fill(updatedFollowUpAppointment);
+    await this.page.locator('#dischargeInstructionsAdditionalInstructions').fill(updatedAdditionalInstructions);
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(2000);
+  }
+
+  async fillProcedureNoteForm() {
+    await this.page.locator('#procedureNoteProcedure').fill(procedure);
+    await this.page.locator('#procedureNoteIndication').fill(indication);
+    await this.page.locator('#procedureNotePhysician').fill(physcian);
+    await this.page.locator('#procedureNoteConsent').fill(consent);
+    await this.page.locator('label').filter({ hasText: /local anesthesia and sedation/i }).locator('span').first().click();
+    await this.page.locator('#procedureNoteProcedureSummary').fill(procedureSummary);
+    await this.page.locator('#procedureNoteComplecations').fill(complications);
+  }
+
+  async updateProcedureNote() {
+    await this.page.getByRole('button', { name: /edit this encounter/i }).click();
+    await this.page.locator('#procedureNoteConsent').fill(updatedConsent);
+    await this.page.locator('label').filter({ hasText: /monitored anesthesia care/i }).locator('span').first().click();
+    await this.page.locator('#procedureNoteProcedureSummary').fill(UpdatedProcedureSummary);
+    await this.page.locator('#procedureNoteComplecations').fill(updatedComplications);
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(2000);
+  }
+
+  async fillDischargeSummaryForm() {
+    await this.page.getByRole('combobox', { name: /diagnosis/i }).click();
+    await this.page.getByText(/acute cholecystitis/i).click();
+    await this.page.locator('#dischargeSummaryProcedures').fill(procedure);
+    await this.page.locator('#dischargeSummaryConsultations').fill(consultations);
+    await this.page.locator('#dischargeSummaryHospitalCourse').fill(hospitalCourse);
+    await this.page.locator('#dischargeSummaryDischargeTo').fill(dischargeTo);
+    await this.page.locator('#dischargeSummaryDischargeMedication').fill(dischargeMedications);
+    await this.page.locator('#dischargeSummaryDischargeInstructions').fill(dischargeInstructions);
+  }
+
+  async updateDischargeSummary() {
+    await this.page.getByRole('button', { name: /edit this encounter/i }).click();
+    await this.page.getByRole('combobox', { name: /diagnosis/i }).click();
+    await this.page.getByText(/acute peptic ulcer with perforation/i).click();
+    await this.page.locator('#dischargeSummaryProcedures').fill(procedure);
+    await this.page.locator('#dischargeSummaryConsultations').fill(updatedConsultations);
+    await this.page.locator('#dischargeSummaryHospitalCourse').fill(updatedHospitalCourse);
+    await this.page.locator('#dischargeSummaryDischargeMedication').fill(updatedDischargeMedications);
+    await this.page.locator('#dischargeSummaryDischargeInstructions').fill(updatedDischargeInstructions);
+    await this.page.getByRole('button', { name: /save/i }).click(), delay(2000);
+  }
+
+  async saveForm() {
+    await this.page.getByRole('button', { name: /save/i }).click();
+    await expect(this.page.getByText(/form submitted successfully/i)).toBeVisible();
+  }
+}

--- a/e2e/utils/pages/conditions-page.ts
+++ b/e2e/utils/pages/conditions-page.ts
@@ -20,7 +20,7 @@ export class ConditionsPage {
     await expect(this.page.getByText(/condition saved successfully/i)).toBeVisible();
   }
 
-  async editPatientCondition() {
+  async updatePatientCondition() {
     await this.page.getByRole('button', { name: /options/i }).click();
     await this.page.getByRole('menuitem', { name: /edit/i }).click();
     await this.page.locator('label').filter({ hasText: 'Inactive' }).click();

--- a/e2e/utils/pages/program-page.ts
+++ b/e2e/utils/pages/program-page.ts
@@ -22,12 +22,12 @@ export class ProgramsPage {
     await expect(this.page.getByText(/program enrollment saved/i)).toBeVisible(), delay(3000);
   }
 
-  async editPatientProgramEnrollment() {
+  async updatePatientProgramEnrollment() {
     await this.editProgramButton().click();
     await this.page.locator('#enrollmentDateInput').clear();
-    await this.page.locator('#enrollmentDateInput').fill('16/08/2024');
+    await this.page.locator('#enrollmentDateInput').fill('16/09/2024');
     await this.page.locator('#completionDateInput').clear();
-    await this.page.locator('#completionDateInput').fill('21/08/2024');
+    await this.page.locator('#completionDateInput').fill('21/09/2024');
     await this.page.locator('#completionDateInput').press('Tab');
     await this.page.locator('#location').selectOption('Community Outreach');
     await this.page.getByRole('button', { name: /save and close/i }).click();

--- a/e2e/utils/pages/visit-note-page.ts
+++ b/e2e/utils/pages/visit-note-page.ts
@@ -1,13 +1,13 @@
 import { expect, type Page } from '@playwright/test';
 
-export class VisitNotePage {
+export class DiagnosisPage {
   constructor(readonly page: Page) {}
 
-  async navigateToVisitNotePage() {
+  async navigateToDiagnosisPage() {
     await this.page.getByLabel(/visit note/i).click();
   }
 
-  async addVisitNote() {
+  async addDiagnosis() {
     await this.page.getByPlaceholder(/choose a primary diagnosis/i).fill('Diabetic ketoacidosis');
     await this.page.getByRole('menuitem', { name: /diabetic ketoacidosis/i }).click();
     await this.page.getByPlaceholder(/write any notes here/i).fill('Patient has excessive thirst, frequent urination, nausea and vomiting');
@@ -15,7 +15,7 @@ export class VisitNotePage {
     await expect(this.page.getByText(/visit note saved/i)).toBeVisible();
   }
 
-  async deleteVisitNote() {
+  async deleteDiagnosis() {
     await this.page.getByRole('tab', { name: /all encounters/i }).click();
     await this.page.getByRole('button', { name: /options/i }).nth(0).click();
     await this.page.getByRole('menuitem', { name: /delete this encounter/i }).click();

--- a/e2e/utils/pages/visits-page.ts
+++ b/e2e/utils/pages/visits-page.ts
@@ -20,7 +20,7 @@ export class VisitsPage {
     await expect(this.page.getByText(/facility visit started successfully/i)).toBeVisible(), delay(3000);
   }
 
-  async editPatientVisit() {
+  async updatePatientVisit() {
     await this.page.getByRole('button', { name: /edit visit details/i }).click();
     await this.page.locator('label').filter({ hasText: 'Home Visit' }).locator('span').first().click();
     await this.page.getByRole('button', { name: /update visit/i }).click(), delay(3000);


### PR DESCRIPTION
This PR adds e2e tests for the Discharge Summary, Discharge Instructions, Procedure Note, and Visit Note forms, covering add, edit, and delete scenarios.

Reference: https://www.notion.so/mekom/134e2970ade1808996bbd1f108db6fff?v=800622881a14483abd430730018a7924&p=134e2970ade180c79a0dfdae6c112493&pm=s