### PR TITLE
Add e2e tests for Surgical Operation form

### DIFF
--- a/e2e/tests/surgical-operation-form.spec.ts
+++ b/e2e/tests/surgical-operation-form.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { delay, HomePage } from '../utils/pages/home-page';
+import { VisitsPage } from '../utils/pages/visits-page';
+import { RegistrationPage } from '../utils/pages/registration-page';
+import { ClinicalFormsPage } from '../utils/pages/clinical-forms-page';
+
+let homePage: HomePage;
+let visitsPage: VisitsPage;
+let registrationPage: RegistrationPage;
+let formsPage: ClinicalFormsPage;
+
+test.beforeEach(async ({ page }) => {
+  homePage = new HomePage(page);
+  visitsPage = new VisitsPage(page);
+  formsPage = new ClinicalFormsPage(page);
+  registrationPage = new RegistrationPage(page);
+
+  await homePage.login();
+  await registrationPage.navigateToRegistrationForm();
+  await registrationPage.createPatient();
+  await visitsPage.startPatientVisit();
+  await formsPage.navigateToClinicalForms();
+});
+
+test('Add surgical operation instructions', async ({ page }) => {
+  // setup
+  await formsPage.navigateToSurgicalOperationForm();
+
+  // replay
+  await formsPage.fillSurgicalOperationForm();
+  await formsPage.saveForm();
+
+  // verify
+  await visitsPage.navigateToVisitsPage();
+  await page.getByRole('tab', { name: /Encounters/, exact: true }).click();
+  await expect(page.getByRole('cell', {name: /surgical operation/i})).toBeVisible();
+  await page.getByRole('button', { name: /expand current row/i }).click();
+  await expect(page.locator('//span[normalize-space()="Pre-Operative Diagnosis"]/following-sibling::span[1]')).toHaveText(/acute appendicitis/i);
+  await expect(page.locator('//span[normalize-space()="Post-Operative Diagnosis"]/following-sibling::span[1]')).toHaveText(/acute suppurative Appendicitis/i);
+  await expect(page.locator('//span[normalize-space()="Procedure"]/following-sibling::span[1]')).toHaveText(/Laparoscopic appendectomy/i);
+  await expect(page.locator('//span[normalize-space()="Estimated Blood Loss"]/following-sibling::span[1]')).toHaveText(/2.0/i);
+  await expect(page.locator('//span[normalize-space()="Assistants"]/following-sibling::span[1]')).toHaveText(/Nurse Alex Johnson/i);
+  await expect(page.locator('//span[normalize-space()="Complications"]/following-sibling::span[1]')).toHaveText(/none/i);
+  await expect(page.locator('//span[normalize-space()="Specimens"]/following-sibling::span[1]')).toHaveText(/appendix sent for histopathological examination/i);
+  await expect(page.locator('//span[normalize-space()="Surgeon"]/following-sibling::span[1]')).toHaveText(/Dr. Jane Smith/);
+  await expect(page.locator('//span[normalize-space()="Anesthesia Type"]/following-sibling::span[1]')).toHaveText(/general/i);
+  await expect(page.locator('//span[normalize-space()="Post-Operative Instructions"]/following-sibling::span[1]')).toHaveText(/pain management with paracetamol and morphine as needed/i);
+  });
+
+  test('Estimated blood loss field should allow valid input', async ({ page }) => {
+    // setup
+    await formsPage.navigateToSurgicalOperationForm();
+
+    // replay
+    await page.getByRole('spinbutton', { name: /estimated blood loss/i }).fill('-1'), delay(2000);
+    await expect(page.getByText(/value must be greater than 0/i)).toBeVisible();
+    await page.getByRole('spinbutton', { name: /estimated blood loss/i }).clear();
+    await page.getByRole('spinbutton', { name: /estimated blood loss/i }).fill('0'), delay(2000);
+    await expect(page.getByText(/error/i)).not.toBeVisible();
+    await page.getByRole('spinbutton', { name: /estimated blood loss/i }).clear();
+    await page.getByRole('spinbutton', { name: /estimated blood loss/i }).fill('1'), delay(2000);
+    await formsPage.saveForm();
+
+    // verify
+    await visitsPage.navigateToVisitsPage();
+    await page.getByRole('tab', { name: /Encounters/, exact: true }).click();
+    await expect(page.getByRole('cell', {name: /surgical operation/i})).toBeVisible();
+    await page.getByRole('button', { name: /expand current row/i }).click();
+    await expect(page.locator('//div[span[1][normalize-space()="Estimated Blood Loss"]]/span[2]')).toHaveText('1.0');
+    });
+
+  test.afterEach(async ({ }) => {
+    await homePage.voidPatient();
+  });

--- a/e2e/utils/pages/clinical-forms-page.ts
+++ b/e2e/utils/pages/clinical-forms-page.ts
@@ -35,16 +35,26 @@ export class ClinicalFormsPage {
   readonly formsTable = () => this.page.getByRole('table', { name: /forms/i });
 
   async navigateToClinicalForms() {
-    await this.page.getByLabel(/clinical forms/i, { exact: true }).click();
+    await this.page.getByRole('button', { name: /clinical forms/i }).click();
     await expect(this.page.getByRole('cell', { name: /discharge instructions/i, exact: true })).toBeVisible();
     await expect(this.page.getByRole('cell', { name: /discharge summary/i, exact: true })).toBeVisible();
     await expect(this.page.getByRole('cell', { name: /procedure note/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /visit note/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /surgical operation/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /soap note template/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /ward admission/i, exact: true })).toBeVisible();
+    await expect(this.page.getByRole('cell', { name: /laboratory test results/i, exact: true })).toBeVisible();
     await expect(this.page.getByRole('cell', { name: /visit note/i, exact: true })).toBeVisible();
   }
 
   async navigateToVisitNoteForm() {
     await this.page.getByText(/Visit Note/).click();
     await expect(this.page.getByText(/Visit Note/)).toBeVisible();
+  }
+
+  async navigateToSurgicalOperationForm() {
+    await this.page.getByText(/surgical operation/i).click();
+    await expect(this.page.getByText(/surgical operation/i).first()).toBeVisible();
   }
 
   async navigateToDischargeInstructionsForm() {
@@ -148,6 +158,19 @@ export class ClinicalFormsPage {
     await this.page.locator('#dischargeSummaryDischargeMedication').fill(updatedDischargeMedications);
     await this.page.locator('#dischargeSummaryDischargeInstructions').fill(updatedDischargeInstructions);
     await this.page.getByRole('button', { name: /save/i }).click(), delay(2000);
+  }
+
+  async fillSurgicalOperationForm() {
+    await this.page.getByRole('textbox', { name: /pre-operative diagnosis/i }).fill('Acute appendicitis');
+    await this.page.getByRole('textbox', { name: /post-operative diagnosis/i }).fill('Acute suppurative Appendicitis');
+    await this.page.getByRole('textbox', { name: /procedure/i }).fill('Laparoscopic appendectomy');
+    await this.page.getByRole('textbox', { name: /assistants/i }).fill('Nurse Alex Johnson');
+    await this.page.locator('label').filter({ hasText: /general/i }).locator('span').first().click();
+    await this.page.getByRole('spinbutton', { name: /estimated blood loss/i }).fill('2');
+    await this.page.getByRole('textbox', { name: /complications/i }).fill('None');
+    await this.page.getByRole('textbox', { name: /specimens/i }).fill('Appendix sent for histopathological examination');
+    await this.page.getByRole('textbox', { name: /surgeon/i }).fill('Dr. Jane Smith');
+    await this.page.getByRole('textbox', { name: /post-operative instructions/i }).fill('Pain management with paracetamol and morphine as needed');
   }
 
   async saveForm() {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "faimer-e2e": "npx playwright test surgical"
+    "faimer-e2e": "npx playwright test"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "faimer-e2e": "npx playwright test"
+    "faimer-e2e": "npx playwright test surgical"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR adds e2e tests for Surgical Operation forms and includes tests for:

- adding surgical operation instructions.
- estimated blood loss field  to allow valid input.