### PR TITLE
Add e2e tests for imaging orders

### DIFF
--- a/e2e/tests/drug-orders.spec.ts
+++ b/e2e/tests/drug-orders.spec.ts
@@ -11,7 +11,9 @@ let visitsPage: VisitsPage;
 let chartPage: ChartPage;
 let ordersPage: OrdersPage;
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page, context }) => {
+  await context.clearCookies();
+  await context.clearPermissions();
   homePage = new HomePage(page);
   keycloak = new Keycloak(page);
   visitsPage = new VisitsPage(page);
@@ -40,7 +42,7 @@ test('Add a drug order', async ({ page }) => {
   await page.getByRole('searchbox').fill('Aspirin 325mg');
   await page.getByRole('button', { name: /order form/i }).click();
   await ordersPage.fillDrugOrderForm();
-  await ordersPage.saveDrugOrder();
+  await ordersPage.saveOrder();
 
   // verify
   await chartPage.navigateToMedicationsPage();
@@ -66,7 +68,7 @@ test('Modify a drug order', async ({ page }) => {
   await page.getByRole('searchbox').fill('Aspirin 325mg');
   await page.getByRole('button', { name: /order form/i }).click();
   await ordersPage.fillDrugOrderForm();
-  await ordersPage.saveDrugOrder();
+  await ordersPage.saveOrder();
   await chartPage.navigateToMedicationsPage();
   await expect(page.getByText(/aspirin 325mg/i).nth(0)).toBeVisible();
   await expect(page.getByText(/12 tablet/i).nth(0)).toBeVisible();
@@ -104,7 +106,7 @@ test('Discontinue a drug order', async ({ page }) => {
   await page.getByRole('searchbox').fill('Aspirin 325mg');
   await page.getByRole('button', { name: /order form/i }).click();
   await ordersPage.fillDrugOrderForm();
-  await ordersPage.saveDrugOrder();
+  await ordersPage.saveOrder();
   await chartPage.navigateToMedicationsPage();
   await expect(page.getByText(/aspirin 325mg/i).nth(0)).toBeVisible();
   await expect(page.getByText(/12 tablet/i).nth(0)).toBeVisible();
@@ -141,7 +143,7 @@ test('Add a drug order with free text dosage', async ({ page }) => {
   await page.getByLabel(/quantity to dispense/i).fill('18');
   await page.getByLabel(/prescription refills/i).fill('2');
   await page.locator('#indication').fill('Hypertension');
-  await ordersPage.saveDrugOrder();
+  await ordersPage.saveOrder();
 
   // verify
   await chartPage.navigateToMedicationsPage();

--- a/e2e/tests/imaging-orders.spec.ts
+++ b/e2e/tests/imaging-orders.spec.ts
@@ -26,7 +26,7 @@ test.beforeEach(async ({ page, context }) => {
   await keycloak.createUser();
 });
 
-test('Add a lab test', async ({ page }) => {
+test('Add an imaging order', async ({ page }) => {
   // setup
   await homePage.navigateToLoginPage();
   await homePage.loginWithUser();
@@ -38,49 +38,49 @@ test('Add a lab test', async ({ page }) => {
 
   // replay
   await chartPage.navigateToOrderBasket();
-  await ordersPage.navigateToLabOrderForm();
-  await page.getByRole('searchbox').fill('Bacteriuria test, urine'), delay(2500);
+  await ordersPage.navigateToImagingOrderForm();
+  await page.getByRole('searchbox').fill('CT cervical spine'), delay(2500);
   await page.getByRole('button', { name: /order form/i }).click();
   await ordersPage.saveOrder();
 
   // verify
   await ordersPage.navigateToOrdersPage();
-  await expect(page.locator("//tr[td[text()='Test order']]").nth(0)).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Bacteriuria test, urine']]")).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Bacteriuria test, urine']]//div[@data-priority='routine']")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders']]").nth(0)).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='CT cervical spine']]")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='CT cervical spine']]//div[@data-priority='routine']")).toBeVisible();
 });
 
-test('Modify a lab order', async ({ page }) => {
+test('Modify an imaging order', async ({ page }) => {
   // setup
   await homePage.navigateToLoginPage();
   await homePage.loginWithUser();
   await homePage.patientSearchIcon().click();
-  await homePage.patientSearchBar().fill('Daichi Okada'), delay(2000);
+  await homePage.patientSearchBar().fill('Devan Modi'), delay(2000);
   await expect(page.getByText('1 search result')).toBeVisible();
-  await homePage.clickOnPatientResult('Daichi Okada');
+  await homePage.clickOnPatientResult('Devan Modi');
   await visitsPage.startPatientVisit();
   await chartPage.navigateToOrderBasket();
-  await ordersPage.navigateToLabOrderForm();
-  await page.getByRole('searchbox').fill('Blood urea nitrogen'), delay(2500);
+  await ordersPage.navigateToImagingOrderForm();
+  await page.getByRole('searchbox').fill('X Ray soft tissue neck'), delay(2500);
   await page.getByRole('button', { name: /order form/i }).click();
   await ordersPage.saveOrder();
   await ordersPage.navigateToOrdersPage();
-  await expect(page.locator("//tr[td[text()='Test order']]").nth(0)).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Blood urea nitrogen']]")).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Blood urea nitrogen']]//div[@data-priority='routine']")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders']]").nth(0)).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='X Ray soft tissue neck']]")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='X Ray soft tissue neck']]//div[@data-priority='routine']")).toBeVisible();
 
   // replay
-  await ordersPage.modifyLabOrder();
+  await ordersPage.modifyImagingOrder();
   await ordersPage.saveOrder();
 
   // verify
-  await expect(page.locator("//tr[td[text()='Test order']]").nth(0)).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Blood urea nitrogen']]")).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Blood urea nitrogen']]//div[@data-priority='routine']")).not.toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Blood urea nitrogen']]//div[@data-priority='stat']")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders']]").nth(0)).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='X Ray soft tissue neck']]")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='X Ray soft tissue neck']]//div[@data-priority='routine']")).not.toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='X Ray soft tissue neck']]//div[@data-priority='stat']")).toBeVisible();
 });
 
-test('Discontinue a lab order', async ({ page }) => {
+test('Discontinue an imaging order', async ({ page }) => {
   // setup
   await homePage.navigateToLoginPage();
   await homePage.loginWithUser();
@@ -90,21 +90,21 @@ test('Discontinue a lab order', async ({ page }) => {
   await homePage.clickOnPatientResult('Florencia Klinger');
   await visitsPage.startPatientVisit();
   await chartPage.navigateToOrderBasket();
-  await ordersPage.navigateToLabOrderForm();
-  await page.getByRole('searchbox').fill('Complete blood count'), delay(2500);
+  await ordersPage.navigateToImagingOrderForm();
+  await page.getByRole('searchbox').fill('MRI brain (with contrast)'), delay(2500);
   await page.getByRole('button', { name: /order form/i }).click();
   await ordersPage.saveOrder();
   await ordersPage.navigateToOrdersPage();
-  await expect(page.locator("//tr[td[text()='Test order']]").nth(0)).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Complete blood count']]")).toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Complete blood count']]//div[@data-priority='routine']")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders']]").nth(0)).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='MRI brain (with contrast)']]")).toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='MRI brain (with contrast)']]//div[@data-priority='routine']")).toBeVisible();
 
   // replay
   await ordersPage.cancelOrder();
 
   // verify
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Complete blood count']]")).not.toBeVisible();
-  await expect(page.locator("//tr[td[text()='Test order'] and td[text()='Complete blood count']]//div[@data-priority='routine']")).not.toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='MRI brain (with contrast)']]")).not.toBeVisible();
+  await expect(page.locator("//tr[td[text()='Imaging orders'] and td[text()='MRI brain (with contrast)']]//div[@data-priority='routine']")).not.toBeVisible();
 });
 
 test.afterEach(async ({ browser }) => {

--- a/e2e/utils/pages/chart-page.ts
+++ b/e2e/utils/pages/chart-page.ts
@@ -1,4 +1,5 @@
 import { type Page } from '@playwright/test';
+import { delay } from './home-page';
 
 export class ChartPage {
   constructor(readonly page: Page) {}
@@ -7,7 +8,7 @@ export class ChartPage {
   readonly medicationsTable = () => this.page.getByRole('table', { name: /medications/i });
 
   async navigateToOrderBasket() {
-    await this.orderBasketButton().click();
+    await this.orderBasketButton().click(), delay(3000);
   }
 
   async navigateToMedicationsPage() {

--- a/e2e/utils/pages/orders-page.ts
+++ b/e2e/utils/pages/orders-page.ts
@@ -10,39 +10,33 @@ export class OrdersPage {
     await this.page.getByRole('link', { name: /orders/i }).click();
   }
 
-  async navigateToLabOrderForm() {
-    await expect(this.page.locator('div').filter({ hasText: /^Drug orders \(0\)AddViewLab orders \(0\)AddView$/ }).getByRole('button').nth(2)).toBeVisible();
-    await this.page.locator('div').filter({ hasText: /^Drug orders \(0\)AddViewLab orders \(0\)AddView$/ }).getByRole('button').nth(2).click();
-  }
-
   async navigateToDrugOrderForm() {
-    await expect(this.page.locator('div').filter({ hasText: /^Drug orders \(0\)AddViewLab orders \(0\)AddView$/ }).getByRole('button').first()).toBeVisible();
-    await this.page.locator('div').filter({ hasText: /^Drug orders \(0\)AddViewLab orders \(0\)AddView$/ }).getByRole('button').first().click();
+    await expect(this.page.locator('text=Drug orders').locator('xpath=../..').locator('button:has-text("Add")')).toBeVisible();
+    await this.page.locator('text=Drug orders').locator('xpath=../..').locator('button:has-text("Add")').click();
+  }
+  async navigateToLabOrderForm() {
+    await expect(this.page.locator('text=Lab orders').locator('xpath=../..').locator('button:has-text("Add")')).toBeVisible();
+    await this.page.locator('text=Lab orders').locator('xpath=../..').locator('button:has-text("Add")').click();
   }
 
-  async saveLabOrder() {
-    await this.page.waitForSelector('button:has-text("save order")');
-    await this.page.getByRole('button', { name: /save order/i }).click(), delay(3000);
-    await this.page.waitForSelector('button:has-text("sign and close")');
-    await this.page.getByRole('button', { name: /sign and close/i }).click();
-    await expect(this.page.getByText(/error/i)).not.toBeVisible();
-    await expect(this.page.getByText(/placed orders/i)).toBeVisible(), delay(5000);
+  async navigateToImagingOrderForm() {
+    await expect(this.page.locator('text=Imaging orders').locator('xpath=../..').locator('button:has-text("Add")')).toBeVisible();
+    await this.page.locator('text=Imaging orders').locator('xpath=../..').locator('button:has-text("Add")').click();
   }
 
   async modifyLabOrder() {
     await this.page.getByRole('button', { name: /options/i }).nth(0).click();
     await this.page.getByRole('menuitem', { name: /modify order/i }).click();
-    await expect(this.page.getByRole('cell', { name: /bacteriuria test, urine/i })).toBeVisible();
     await this.page.locator('#labReferenceNumberInput').fill('202');
     await this.page.getByLabel('Priority').selectOption('STAT');
     await this.page.getByLabel(/additional instructions/i).fill('Take urine sample'), delay(2000);
   }
 
-  async cancelLabOrder() {
-    await this.page.getByRole('button', { name: /options/i }).nth(0).click(), delay(2000);
-    await this.page.getByRole('menuitem', { name: /cancel order/i }).click(), delay(3000);
-    await this.page.getByRole('button', { name: /sign and close/i }).click();
-    await expect(this.page.getByText(/discontinued Blood urea nitrogen/i)).toBeVisible();
+  async modifyImagingOrder() {
+    await this.page.getByRole('button', { name: /options/i }).nth(0).click();
+    await this.page.getByRole('menuitem', { name: /modify order/i }).click();
+    await this.page.getByLabel('Priority').selectOption('STAT');
+    await this.page.getByLabel(/additional instructions/i).fill('Patient has stridor and difficulty swallowing. Please obtain AP and lateral views with the patient in an upright position if tolerated'), delay(2000);
   }
 
   async fillDrugOrderForm() {
@@ -58,10 +52,12 @@ export class OrdersPage {
     await this.page.locator('#indication').fill('Hypertension');
   }
 
-  async saveDrugOrder() {
+  async saveOrder() {
     await this.page.getByRole('button', { name: /save order/i }).click(), delay(3000);
     await this.page.getByRole('button', { name: /sign and close/i }).focus();
-    await this.page.getByRole('button', { name: /sign and close/i }).click();
+    await this.page.getByRole('button', { name: /sign and close/i }).click(), delay(1000);
+    await expect(this.page.getByText(/error/i)).not.toBeVisible();
+    await expect(this.page.getByText(/placed orders/i)).toBeVisible(), delay(5000);
   }
 
   async modifyDrugOrder() {
@@ -75,7 +71,9 @@ export class OrdersPage {
     await this.page.getByRole('button', { name: /save order/i }).dispatchEvent('click');
     await expect(this.page.getByText(/sign and close/i)).toBeVisible();
     await this.page.getByRole('button', { name: /sign and close/i }).focus();
-    await this.page.getByRole('button', { name: /sign and close/i }).dispatchEvent('click');
+    await this.page.getByRole('button', { name: /sign and close/i }).dispatchEvent('click'), delay(1000);
+    await expect(this.page.getByText(/error/i)).not.toBeVisible();
+    await expect(this.page.getByText(/placed orders/i)).toBeVisible(), delay(5000);
   }
 
   async discontinueDrugOrder() {
@@ -84,6 +82,16 @@ export class OrdersPage {
     await expect(this.page.getByText(/discontinue/i)).toBeVisible();
     await expect(this.page.getByText(/sign and close/i)).toBeVisible();
     await this.page.getByRole('button', { name: /sign and close/i }).focus();
-    await this.page.getByRole('button', { name: /sign and close/i }).dispatchEvent('click');
+    await this.page.getByRole('button', { name: /sign and close/i }).dispatchEvent('click'), delay(1000);
+    await expect(this.page.getByText(/error/i)).not.toBeVisible();
+    await expect(this.page.getByText(/discontinued/)).toBeVisible();
+  }
+
+  async cancelOrder() {
+    await this.page.getByRole('button', { name: /options/i }).nth(0).click(), delay(2000);
+    await this.page.getByRole('menuitem', { name: /cancel order/i }).click(), delay(3000);
+    await this.page.getByRole('button', { name: /sign and close/i }).click(), delay(1000);
+    await expect(this.page.getByText(/error/i)).not.toBeVisible();
+    await expect(this.page.getByText(/discontinued/i)).toBeVisible();
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "faimer-e2e": "npx playwright test"
+    "faimer-e2e": "npx playwright test imaging-orders"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "!playwright-report/"
   ],
   "scripts": {
-    "faimer-e2e": "npx playwright test imaging-orders"
+    "faimer-e2e": "npx playwright test"
   },
   "keywords": [],
   "author": "",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,6 @@ const config: PlaywrightTestConfig = {
   globalSetup: require.resolve('./e2e/utils/configs/globalSetup'),
   use: {
     baseURL: `${process.env.O3_URL_DEV}/spa/`,
-    storageState: 'e2e/storageState.json',
   },
   projects: [
     {
@@ -24,6 +23,9 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices['Desktop Chromium'],
         viewport: { width: 1920, height: 1080 },
+        launchOptions: {
+          args: ['--incognito'],
+        }
       },
       
     },


### PR DESCRIPTION
This PR adds e2e tests for imaging orders covering the following test cases:

- Adding an imaging order
- Modifying an imaging order
- Discontinuing an imaging order