### PR TITLE
Remove `launchOptions` to run tests in a regular browser.

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,9 +23,6 @@ const config: PlaywrightTestConfig = {
       use: {
         ...devices['Desktop Chromium'],
         viewport: { width: 1920, height: 1080 },
-        launchOptions: {
-          args: ['--incognito'],
-        }
       },
       
     },


### PR DESCRIPTION
Ref: https://mekomsolutions.slack.com/archives/G421UNF5L/p1745929904893709?thread_ts=1745854916.603859&cid=G421UNF5L