### PR TITLE
Allow selecting test environment at runtime on GA

### DIFF
--- a/.env
+++ b/.env
@@ -3,18 +3,25 @@
 # It sets a bunch of envvars that drive the behaviour of the automated E2E test suite.
 #
 
+# The target environment that will be tested.
+# Possible values are dev, qa
+TEST_ENVIRONMENT=dev
+
 #
-# O3 URL for dev environment.
+# Ozone URL for dev and qa environments.
 #
 
 # OpenMRS
 O3_URL_DEV=https://oz-faimer-dev.mekomsolutions.net
+O3_URL_QA=https://ehr.faimer.org
 
 # Keycloak
 KEYCLOAK_URL_DEV=https://auth.oz-faimer-dev.mekomsolutions.net
+KEYCLOAK_URL_QA=https://auth.ehr.faimer.org
 
 # Iframe
 IFRAME_URL_DEV=https://iframe.oz-faimer-dev.mekomsolutions.net
+IFRAME_URL_QA=https://iframe.ehr.faimer.org
 
 # O3 test user credentials
 O3_PASSWORD=password

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,15 @@ on:
     branches: [main]
 
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Choose test environment'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - qa
 
 jobs:
   build:
@@ -32,6 +41,7 @@ jobs:
 
       - name: Run E2E tests
         env:
+          TEST_ENVIRONMENT: '${{ github.event.inputs.environment }}'
           KEYCLOAK_USERNAME: '${{ secrets.KEYCLOAK_USERNAME }}'
           KEYCLOAK_PASSWORD: '${{ secrets.KEYCLOAK_PASSWORD }}'
         run: npm run faimer-e2e

--- a/e2e/tests/drug-orders.spec.ts
+++ b/e2e/tests/drug-orders.spec.ts
@@ -82,12 +82,9 @@ test('Modify a drug order', async ({ page }) => {
   await ordersPage.modifyDrugOrder();
 
   // verify
-  await chartPage.navigateToMedicationsPage();
   await expect(page.getByText(/aspirin 325mg/i).nth(0)).toBeVisible();
-  await expect(page.getByText(/12 tablet/i)).not.toBeVisible();
-  await expect(page.getByText(/8 tablet/i)).not.toBeVisible();
+  await expect(page.getByText(/8 tablet/i).nth(0)).toBeVisible();
   await expect(page.getByText(/thrice daily/i).nth(0)).toBeVisible();
-  await expect(page.getByText(/5 days/i)).not.toBeVisible();
   await expect(page.getByText(/6 days/i).nth(0)).toBeVisible();
 });
 
@@ -118,7 +115,7 @@ test('Discontinue a drug order', async ({ page }) => {
   await ordersPage.discontinueDrugOrder();
 
   // verify
-  await expect(page.getByText(/aspirin 325mg/i)).not.toBeVisible();
+  await expect(page.locator('p', { hasText: 'Aspirin 325mg' })).toContainText('Discontinued');
 });
 
 test('Add a drug order with free text dosage', async ({ page }) => {

--- a/e2e/utils/configs/globalSetup.ts
+++ b/e2e/utils/configs/globalSetup.ts
@@ -11,6 +11,9 @@ import {
 
 dotenv.config();
 
+export const O3_URL = `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.O3_URL_QA}` : `${process.env.O3_URL_DEV}`;
+export const KEYCLOAK_URL = `${process.env.TEST_ENVIRONMENT}` == 'qa' ? `${process.env.KEYCLOAK_URL_QA}` : `${process.env.KEYCLOAK_URL_DEV}`;
+
 async function globalSetup() {
   const requestContext = await request.newContext();
   const token = Buffer.from(`${process.env.O3_USERNAME}:${process.env.O3_PASSWORD}`).toString(

--- a/e2e/utils/pages/home-page.ts
+++ b/e2e/utils/pages/home-page.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { user, userThree, userTwo } from './keycloak';
+import { O3_URL } from '../configs/globalSetup';
 
 export const delay = (mills) => {
   const endTime = Date.now() + mills;
@@ -19,7 +20,7 @@ export class HomePage {
   readonly wardsButton = () => this.page.getByRole('link', { name: /wards/i });
 
   async navigateToLoginPage() {
-    await this.page.goto(`${process.env.O3_URL_DEV}`);
+    await this.page.goto(`${O3_URL}`);
     await expect(this.page.locator('#username')).toBeVisible();
     await expect(this.page.locator('#password')).toBeVisible();
   }
@@ -49,7 +50,7 @@ export class HomePage {
   }
 
   async navigateToHomePage() {
-    await this.page.goto(`${process.env.O3_URL_DEV}/openmrs/spa/home`);
+    await this.page.goto(`${O3_URL}/openmrs/spa/home`);
     await expect(this.page).toHaveURL(/.*home/);
   }
 

--- a/e2e/utils/pages/keycloak.ts
+++ b/e2e/utils/pages/keycloak.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { delay } from './home-page';
+import { KEYCLOAK_URL } from '../configs/globalSetup';
 
 export var user = {
   userName : '',
@@ -27,7 +28,7 @@ export class Keycloak {
   readonly addUserButton = () => this.page.getByTestId('add-user');
 
   async open() {
-    await this.page.goto(`${process.env.KEYCLOAK_URL_DEV}/realms/master/account`);
+    await this.page.goto(`${KEYCLOAK_URL}/realms/master/account`);
     await this.page.getByRole('button', { name: /Sign in/ }).click();
     await this.page.getByLabel(/username or email/i).fill(`${process.env.KEYCLOAK_USERNAME}`);
     await this.page.getByLabel(/password/i).fill(`${process.env.KEYCLOAK_PASSWORD}`);
@@ -36,7 +37,7 @@ export class Keycloak {
   }
   
   async navigateToUsers() {
-    await this.page.goto(`${process.env.KEYCLOAK_URL_DEV}/admin/master/console`);
+    await this.page.goto(`${KEYCLOAK_URL}/admin/master/console`);
     await this.page.getByTestId('realmSelectorToggle').click();
     await expect(this.page.getByRole('menuitem', { name: 'ozone' })).toBeVisible();
     await this.page.getByRole('menuitem', { name: 'ozone' }).click();
@@ -136,7 +137,7 @@ export class Keycloak {
 
   async deleteUser() {
     await this.open();
-    await this.page.goto(`${process.env.KEYCLOAK_URL_DEV}/admin/master/console/#/ozone/users`);
+    await this.page.goto(`${KEYCLOAK_URL}/admin/master/console/#/ozone/users`);
     await this.page.getByRole('textbox', { name: 'search' }).fill(`${user.userName}`);
     await this.page.getByRole('textbox', { name: 'search' }).press('Enter'), delay(1500);
     await this.confirmDelete();
@@ -144,7 +145,7 @@ export class Keycloak {
 
   async deleteUsers() {
     await this.open();
-    await this.page.goto(`${process.env.KEYCLOAK_URL_DEV}/admin/master/console/#/ozone/users`);
+    await this.page.goto(`${KEYCLOAK_URL}/admin/master/console/#/ozone/users`);
     await this.page.getByRole('textbox', { name: 'search' }).fill(`${user.userName}`);
     await this.page.getByRole('textbox', { name: 'search' }).press('Enter'), delay(1500);
     await this.confirmDelete();

--- a/e2e/utils/pages/orders-page.ts
+++ b/e2e/utils/pages/orders-page.ts
@@ -84,7 +84,6 @@ export class OrdersPage {
     await this.page.getByRole('button', { name: /sign and close/i }).focus();
     await this.page.getByRole('button', { name: /sign and close/i }).dispatchEvent('click'), delay(1000);
     await expect(this.page.getByText(/error/i)).not.toBeVisible();
-    await expect(this.page.getByText(/discontinued/)).toBeVisible();
   }
 
   async cancelOrder() {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { devices, PlaywrightTestConfig } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import { O3_URL } from './e2e/utils/configs/globalSetup';
 dotenv.config();
 
 const config: PlaywrightTestConfig = {
@@ -15,7 +16,7 @@ const config: PlaywrightTestConfig = {
   reporter: process.env.CI ? [['junit', { outputFile: 'results.xml' }], ['html']] : [['html']],
   globalSetup: require.resolve('./e2e/utils/configs/globalSetup'),
   use: {
-    baseURL: `${process.env.O3_URL_DEV}/spa/`,
+    baseURL: `${O3_URL}/spa/`,
   },
   projects: [
     {


### PR DESCRIPTION
Reference: https://www.notion.so/mekom/151e2970ade180a5b2b3c3df9dd9f9c2?v=e0850446d4034560b274af7e31b224c1&p=1dce2970ade180308e29fdac978b1340&pm=s

This PR adds ability to allow selecting test environment at runtime on GitHub Actions.
