### PR TITLE
Remove period at end of `Create a patient list`

### DIFF
--- a/e2e/tests/patient-list.spec.ts
+++ b/e2e/tests/patient-list.spec.ts
@@ -25,7 +25,7 @@ test.beforeEach(async ({ page }) => {
   await keycloak.createUser();
 });
 
-test('Create a patient list.', async ({ }) => {
+test('Create a patient list', async ({ }) => {
   // setup
   await homePage.navigateToLoginPage();
   await homePage.loginWithUser();


### PR DESCRIPTION
This PR removes period at the end of the test for better readability of the test name in the README

 > Create a patient list (patient-list.spec.ts)